### PR TITLE
Fix layout

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,20 @@
+module DeviseHelper
+  def devise_error_messages!
+    return '' if resource.errors.empty?
+
+    messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+    html = <<-HTML
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+      <button type="button" class="close" data-dismiss="alert">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <strong>
+       #{pluralize(resource.errors.count, "error")} must be fixed
+      </strong>
+      #{messages}
+    </div>
+    HTML
+
+    html.html_safe
+  end
+end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -13,6 +13,7 @@ module DeviseHelper
       </strong>
       #{messages}
     </div>
+    <br/>
     HTML
 
     html.html_safe

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,9 +1,10 @@
 <br/>
+<%= devise_error_messages! %>
 <div class="booyah-box col-10 offset-1">
   <h2>Sign up</h2>
-  <br/>
+  <br/>    
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-    <%= devise_error_messages! %>
+
     
     <div class="email">
       <%= f.label :email %><br />

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,31 +1,33 @@
+<br/>
 <div class="booyah-box col-10 offset-1">
   <h2>Sign up</h2>
-
+  <br/>
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= devise_error_messages! %>
     
     <div class="email">
       <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Email", class: "form-control"  %>
     </div>
-
+    <br/>
     <div class="field">
       <%= f.label :password %>
       <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em>
       <% end %><br />
-      <%= f.password_field :password, autocomplete: "new-password" %>
+      <%= f.password_field :password, autocomplete: "new-password", placeholder: "Password", class: "form-control"  %>
     </div>
-
+    <br/>
     <div class="field">
       <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "Password", class: "form-control" %>
     </div>
-
+    <br/>
     <div class="actions">
-      <%= f.submit "Sign up" %>
+      <%= f.submit "Sign up", class: 'btn btn-primary' %>
     </div>
   <% end %>
+  <br/>
 
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<br/>
 <div class="booyah-box col-10 offset-1">
 
   <h2>Log in</h2>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,3 +1,5 @@
+<br/>
+<br/>
 <% flash.each do |name, message| %>
   <div class="alert <%= bootstrap_class_for(name) %> alert-dismissible fade show" role="alert">
     <strong><%= bootstrap_string_for(name) %></strong> <%= message %>


### PR DESCRIPTION
This PR resolves the following issues:

fixes #34 

It fixes both the sign up and log in layout and error flash messages.

Example:

![image](https://user-images.githubusercontent.com/30854108/52182579-5201f500-27b3-11e9-81f1-c5f909ee6bce.png)

